### PR TITLE
UID format clarification

### DIFF
--- a/KeyDuino/examples/relay_shield/relay_shield.ino
+++ b/KeyDuino/examples/relay_shield/relay_shield.ino
@@ -8,8 +8,8 @@
 
 #define CHECK_ID true //Change to "true" if you want to check the good ID. If false, every tag will be accepted.
 
-uint8_t RIGHT_UID[4] = { 
-  0XFF, 0XFF, 0XFF, 0XFF }; //The Mifare Classic UID you want to activate relays with.
+uint8_t RIGHT_UID[] = { 
+  0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF }; //The Mifare Classic UID you want to activate relays with.
 
 uint8_t uid[] = { 
   0, 0, 0, 0, 0, 0, 0 };

--- a/KeyDuino/examples/relay_shield/relay_shield.ino
+++ b/KeyDuino/examples/relay_shield/relay_shield.ino
@@ -9,7 +9,7 @@
 #define CHECK_ID true //Change to "true" if you want to check the good ID. If false, every tag will be accepted.
 
 uint8_t RIGHT_UID[] = { 
-  0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF }; //The Mifare Classic UID you want to activate relays with.
+  0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF, 0XFF }; //The Mifare Classic UID you want to activate relays with.
 
 uint8_t uid[] = { 
   0, 0, 0, 0, 0, 0, 0 };


### PR DESCRIPTION
Since most of the example sketches read to serial the UID in 8 byte format, I guess it'd be less confusing for users if the adopted format was unique for every UID used throughout the sketches.